### PR TITLE
Added mutable reference to buffer directly in graphics.

### DIFF
--- a/examples/embedded_linux/src/main.rs
+++ b/examples/embedded_linux/src/main.rs
@@ -105,22 +105,22 @@ fn main() {
     let mut buffer = [0u8; 15000];
 
     // draw something
-    let graphics = Graphics::new(400, 300);
-    graphics.clear(&mut buffer, &Color::White);
-    graphics.draw_line(&mut buffer, 0,0,400,300, &Color::Black); 
+    let mut graphics = Graphics::new(400, 300, &mut buffer);
+    graphics.clear(&Color::White);
+    graphics.draw_line(0,0,400,300, &Color::Black); 
 
-    graphics.draw_filled_rectangle(&mut buffer, 200,200, 230, 230, &Color::Black); 
-    graphics.draw_line(&mut buffer, 202,202,218,228, &Color::White);
+    graphics.draw_filled_rectangle(200,200, 230, 230, &Color::Black); 
+    graphics.draw_line(202,202,218,228, &Color::White);
 
-    graphics.draw_circle(&mut buffer, 200, 150, 130, &Color::Black);
+    graphics.draw_circle(200, 150, 130, &Color::Black);
 
-    graphics.draw_pixel(&mut buffer, 390, 290, &Color::Black);
+    graphics.draw_pixel(390, 290, &Color::Black);
 
-    graphics.draw_horizontal_line(&mut buffer, 0, 150, 400, &Color::Black);
+    graphics.draw_horizontal_line(0, 150, 400, &Color::Black);
 
-    graphics.draw_vertical_line(&mut buffer, 200, 50, 200, &Color::Black);
+    graphics.draw_vertical_line(200, 50, 200, &Color::Black);
 
-    epd4in2.display_and_transfer_frame(&buffer, None).expect("display and transfer error");
+    epd4in2.display_and_transfer_frame(graphics.get_buffer(), None).expect("display and transfer error");
  
     epd4in2.delay_ms(3000);
 
@@ -128,19 +128,19 @@ fn main() {
 
     //Test fast updating a bit more
     let mut small_buffer = [0x00; 128];
-    let circle_graphics = Graphics::new(32,32);
-    circle_graphics.draw_circle(&mut small_buffer, 16,16, 10, &Color::Black);
+    let mut circle_graphics = Graphics::new(32,32, &mut small_buffer);
+    circle_graphics.draw_circle(16,16, 10, &Color::Black);
 
-    epd4in2.set_partial_window(&small_buffer, 16,16, 32, 32, false).expect("Partial Window Error");
+    epd4in2.set_partial_window(circle_graphics.get_buffer(), 16,16, 32, 32, false).expect("Partial Window Error");
     epd4in2.display_frame().expect("Display Frame Error");
 
-    epd4in2.set_partial_window(&small_buffer, 128,64, 32, 32, false).expect("Partial Window Error");
+    epd4in2.set_partial_window(circle_graphics.get_buffer(), 128,64, 32, 32, false).expect("Partial Window Error");
     epd4in2.display_frame().expect("Display Frame Error");
 
-    epd4in2.set_partial_window(&small_buffer, 320,24, 32, 32, false).expect("Partial Window Error");
+    epd4in2.set_partial_window(circle_graphics.get_buffer(), 320,24, 32, 32, false).expect("Partial Window Error");
     epd4in2.display_frame().expect("Display Frame Error");
 
-    epd4in2.set_partial_window(&small_buffer, 160,240, 32, 32, false).expect("Partial Window Error");
+    epd4in2.set_partial_window(circle_graphics.get_buffer(), 160,240, 32, 32, false).expect("Partial Window Error");
     epd4in2.display_frame().expect("Display Frame Error");
 
     epd4in2.delay_ms(3000);
@@ -149,10 +149,10 @@ fn main() {
 
 
     //pub fn draw_string_8x8(&self, buffer: &mut[u8], x0: u16, y0: u16, input: &str, color: &Color) {
-    graphics.draw_string_8x8(&mut buffer, 16, 16, "hello", &Color::Black);
-    graphics.draw_char_8x8(&mut buffer, 250, 250, '#', &Color::Black);
-    graphics.draw_char_8x8(&mut buffer, 300, 16, '7', &Color::Black);
-    epd4in2.display_and_transfer_frame(&buffer, None).expect("display and transfer error");
+    graphics.draw_string_8x8(16, 16, "hello", &Color::Black);
+    graphics.draw_char_8x8(250, 250, '#', &Color::Black);
+    graphics.draw_char_8x8(300, 16, '7', &Color::Black);
+    epd4in2.display_and_transfer_frame(graphics.get_buffer(), None).expect("display and transfer error");
 
     epd4in2.delay_ms(3000);
 


### PR DESCRIPTION
Updated example and tests with the new version.

The &mut Buffer was directly added to the Graphics struct because it was used in nearly every function of the graphics and belongs to the graphics.

To use the buffer outside of the Graphics struct you can now use graphics.get_buffer() to get a reference.