### PR TITLE
Set spi chunk limit on linux with cfg!

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -103,6 +103,7 @@ where
 
         // transfer spi data
         // Be careful!! Linux has a default limit of 4096 bytes per spi transfer
+        // see https://raspberrypi.stackexchange.com/questions/65595/spi-transfer-fails-with-buffer-size-greater-than-4096
         if cfg!(target_os = "linux") {
             for data_chunk in data.chunks(4096) {
                 spi.write(data_chunk)?;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -100,8 +100,17 @@ where
     {
         // activate spi with cs low
         self.cs.set_low();
+
         // transfer spi data
-        spi.write(data)?;
+        // Be careful!! Linux has a default limit of 4096 bytes per spi transfer
+        if cfg!(target_os = "linux") {
+            for data_chunk in data.chunks(4096) {
+                spi.write(data_chunk)?;
+            }
+        } else {
+            spi.write(data)?;
+        }
+        
         // deativate spi with cs high
         self.cs.set_high();
 


### PR DESCRIPTION
Spi.write now uses a max byte chunk size of 4096 on linux device because of a default defined max byte transfer size of 4096 on most linux devices (https://raspberrypi.stackexchange.com/questions/65595/spi-transfer-fails-with-buffer-size-greater-than-4096)

Fixes #13 

