### PR TITLE
Add EPD 4in2bc support

### DIFF
--- a/examples/epd4in2_variable_size.rs
+++ b/examples/epd4in2_variable_size.rs
@@ -70,7 +70,8 @@ fn main() -> Result<(), std::io::Error> {
     let (x, y, width, height) = (50, 50, 250, 250);
 
     let mut buffer = [epd4in2::DEFAULT_BACKGROUND_COLOR.get_byte_value(); 62500]; //250*250
-    let mut display = VarDisplay::new(width, height, &mut buffer, false).unwrap();
+    let mut display =
+        VarDisplay::new(width, height, &mut buffer, DisplayMode::BwrBitOff as u8).unwrap();
     display.set_rotation(DisplayRotation::Rotate0);
     draw_text(&mut display, "Rotate 0!", 5, 50);
 

--- a/src/epd1in54/mod.rs
+++ b/src/epd1in54/mod.rs
@@ -75,7 +75,7 @@ use crate::interface::DisplayInterface;
 pub type Display1in54 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd1in54b/mod.rs
+++ b/src/epd1in54b/mod.rs
@@ -34,7 +34,7 @@ use crate::buffer_len;
 pub type Display1in54b = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -31,7 +31,7 @@ use crate::buffer_len;
 pub type Display1in54c = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd2in13_v2/mod.rs
+++ b/src/epd2in13_v2/mod.rs
@@ -33,7 +33,7 @@ use self::constants::{LUT_FULL_UPDATE, LUT_PARTIAL_UPDATE};
 pub type Display2in13 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -88,7 +88,7 @@ use crate::buffer_len;
 pub type Display2in13bc = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    true,
+    { crate::graphics::DisplayMode::BwrBitOn as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize * 2) },
     TriColor,
 >;

--- a/src/epd2in7b/mod.rs
+++ b/src/epd2in7b/mod.rs
@@ -36,7 +36,7 @@ use crate::buffer_len;
 pub type Display2in7b = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd2in9/mod.rs
+++ b/src/epd2in9/mod.rs
@@ -71,7 +71,7 @@ use crate::interface::DisplayInterface;
 pub type Display2in9 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -94,7 +94,7 @@ use crate::traits::QuickRefresh;
 pub type Display2in9 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -92,7 +92,7 @@ use crate::buffer_len;
 pub type Display2in9bc = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd3in7/mod.rs
+++ b/src/epd3in7/mod.rs
@@ -34,7 +34,7 @@ const IS_BUSY_LOW: bool = false;
 pub type Display3in7 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd4in2bc/mod.rs
+++ b/src/epd4in2bc/mod.rs
@@ -11,9 +11,9 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
+//!    prelude::*, primitives::{Line, PrimitiveStyle},
 //!};
-//!use epd_waveshare::{epd4in2::*, prelude::*};
+//!use epd_waveshare::{epd4in2bc::*, prelude::*};
 //!#
 //!# let expectations = [];
 //!# let mut spi = spi::Mock::new(&expectations);
@@ -25,14 +25,14 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
+//!let mut epd = Epd4in2bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
-//!let mut display = Display4in2::default();
+//!let mut display = Display4in2bc::default();
 //!
 //!// Use embedded graphics for drawing a line
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(PrimitiveStyle::with_stroke(Color::Black, 1))
+//!    .into_styled(PrimitiveStyle::with_stroke(TriColor::Chromatic, 1))
 //!    .draw(&mut display);
 //!
 //!    // Display updated frame
@@ -55,49 +55,47 @@ use embedded_hal::{
 };
 
 use crate::interface::DisplayInterface;
-use crate::traits::{InternalWiAdditions, QuickRefresh, RefreshLut, WaveshareDisplay};
+use crate::traits::{
+    InternalWiAdditions, QuickRefresh, RefreshLut, WaveshareDisplay, WaveshareThreeColorDisplay,
+};
+
+use crate::color::TriColor;
 
 //The Lookup Tables for the Display
-pub mod constants;
+use crate::epd4in2::command::Command;
 use crate::epd4in2::constants::*;
 
-/// Width of the display
-pub const WIDTH: u32 = 400;
-/// Height of the display
-pub const HEIGHT: u32 = 300;
+use crate::epd4in2::HEIGHT;
+use crate::epd4in2::WIDTH;
 /// Default Background Color
-pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
+pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
 const IS_BUSY_LOW: bool = true;
 
-use crate::color::Color;
-
-pub(crate) mod command;
-use self::command::Command;
 use crate::buffer_len;
 
 /// Full size buffer for use with the 4in2 EPD
 #[cfg(feature = "graphics")]
-pub type Display4in2 = crate::graphics::Display<
+pub type Display4in2bc = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    { crate::graphics::DisplayMode::BwrBitOff as u8 },
-    { buffer_len(WIDTH as usize, HEIGHT as usize) },
-    Color,
+    { crate::graphics::DisplayMode::BwrBitOnColorInverted as u8 },
+    { buffer_len(WIDTH as usize, HEIGHT as usize * 2) },
+    TriColor,
 >;
 
-/// Epd4in2 driver
+/// Epd4in2bc driver
 ///
-pub struct Epd4in2<SPI, CS, BUSY, DC, RST, DELAY> {
+pub struct Epd4in2bc<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
     interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
     /// Background Color
-    color: Color,
+    color: TriColor,
     /// Refresh LUT
     refresh: RefreshLut,
 }
 
 impl<SPI, CS, BUSY, DC, RST, DELAY> InternalWiAdditions<SPI, CS, BUSY, DC, RST, DELAY>
-    for Epd4in2<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd4in2bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -121,38 +119,36 @@ where
         self.interface
             .cmd_with_data(spi, Command::BoosterSoftStart, &[0x17, 0x17, 0x17])?;
 
-        // power on
-        self.command(spi, Command::PowerOn)?;
-        delay.delay_us(5000);
-        self.wait_until_idle(spi, delay)?;
-
         // set the panel settings
-        self.cmd_with_data(spi, Command::PanelSetting, &[0x3F])?;
+        self.cmd_with_data(spi, Command::PanelSetting, &[0x0F])?;
 
-        // Set Frequency, 200 Hz didn't work on my board
-        // 150Hz and 171Hz wasn't tested yet
-        // TODO: Test these other frequencies
-        // 3A 100HZ   29 150Hz 39 200HZ  31 171HZ DEFAULT: 3c 50Hz
-        self.cmd_with_data(spi, Command::PllControl, &[0x3A])?;
+        // // Set Frequency, 200 Hz didn't work on my board
+        // // 150Hz and 171Hz wasn't tested yet
+        // // TODO: Test these other frequencies
+        // // 3A 100HZ   29 150Hz 39 200HZ  31 171HZ DEFAULT: 3c 50Hz
+        self.cmd_with_data(spi, Command::PllControl, &[0x3C])?;
 
         self.send_resolution(spi)?;
 
         self.interface
             .cmd_with_data(spi, Command::VcmDcSetting, &[0x12])?;
 
-        //VBDF 17|D7 VBDW 97  VBDB 57  VBDF F7  VBDW 77  VBDB 37  VBDR B7
         self.interface
-            .cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x97])?;
+            .cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x7f])?;
 
         self.set_lut(spi, delay, None)?;
+
+        // power on
+        self.command(spi, Command::PowerOn)?;
+        delay.delay_us(5000);
 
         self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 }
 
-impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareDisplay<SPI, CS, BUSY, DC, RST, DELAY>
-    for Epd4in2<SPI, CS, BUSY, DC, RST, DELAY>
+impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareThreeColorDisplay<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd4in2bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -161,7 +157,60 @@ where
     RST: OutputPin,
     DELAY: DelayUs<u32>,
 {
-    type DisplayColor = Color;
+    fn update_color_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        black: &[u8],
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.update_achromatic_frame(spi, delay, black)?;
+        self.update_chromatic_frame(spi, delay, chromatic)
+    }
+
+    /// Update only the black/white data of the display.
+    ///
+    /// Finish by calling `update_chromatic_frame`.
+    fn update_achromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        _delay: &mut DELAY,
+        black: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, Command::DataStartTransmission1)?;
+        self.interface.data(spi, black)?;
+        Ok(())
+    }
+
+    /// Update only chromatic data of the display.
+    ///
+    /// This data takes precedence over the black/white data.
+    fn update_chromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, Command::DataStartTransmission2)?;
+        self.interface.data(spi, chromatic)?;
+
+        self.wait_until_idle(spi, delay)?;
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareDisplay<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd4in2bc<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayUs<u32>,
+{
+    type DisplayColor = TriColor;
+
     fn new(
         spi: &mut SPI,
         cs: CS,
@@ -172,12 +221,11 @@ where
         delay_us: Option<u32>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_us);
-        let color = DEFAULT_BACKGROUND_COLOR;
 
-        let mut epd = Epd4in2 {
+        let mut epd = Epd4in2bc {
             interface,
-            color,
-            refresh: RefreshLut::Full,
+            color: DEFAULT_BACKGROUND_COLOR,
+            refresh: RefreshLut::Quick,
         };
 
         epd.init(spi, delay)?;
@@ -188,7 +236,7 @@ where
     fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.wait_until_idle(spi, delay)?;
         self.interface
-            .cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x17])?; //border floating
+            .cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x7f])?; //border floating
         self.command(spi, Command::VcmDcSetting)?; // VCOM to 0V
         self.command(spi, Command::PanelSetting)?;
 
@@ -208,11 +256,11 @@ where
         self.init(spi, delay)
     }
 
-    fn set_background_color(&mut self, color: Color) {
+    fn set_background_color(&mut self, color: TriColor) {
         self.color = color;
     }
 
-    fn background_color(&self) -> &Color {
+    fn background_color(&self) -> &TriColor {
         &self.color
     }
 
@@ -231,14 +279,20 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         self.wait_until_idle(spi, delay)?;
-        let color_value = self.color.get_byte_value();
 
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
+        self.interface.data(spi, buffer)?;
+
+        let color_value = self.color.get_byte_value();
+
         self.interface
             .data_x_times(spi, color_value, WIDTH / 8 * HEIGHT)?;
 
         self.interface
             .cmd_with_data(spi, Command::DataStartTransmission2, buffer)?;
+
+        self.command(spi, Command::DataStop)?;
+
         Ok(())
     }
 
@@ -255,43 +309,43 @@ where
         self.wait_until_idle(spi, delay)?;
         if buffer.len() as u32 != width / 8 * height {
             //TODO: panic!! or sth like that
-            //return Err("Wrong buffersize");
+            // return Err("Wrong buffersize");
         }
 
         self.command(spi, Command::PartialIn)?;
         self.command(spi, Command::PartialWindow)?;
+
         self.send_data(spi, &[(x >> 8) as u8])?;
-        let tmp = x & 0xf8;
-        self.send_data(spi, &[tmp as u8])?; // x should be the multiple of 8, the last 3 bit will always be ignored
-        let tmp = tmp + width - 1;
-        self.send_data(spi, &[(tmp >> 8) as u8])?;
-        self.send_data(spi, &[(tmp | 0x07) as u8])?;
+        self.send_data(spi, &[(x & 0xf8) as u8])?; // x should be the multiple of 8, the last 3 bit will always be ignored
+        self.send_data(spi, &[(((x & 0xf8) + width - 1) >> 8) as u8])?;
+        self.send_data(spi, &[(((x & 0xf8) + width - 1) | 0x07) as u8])?;
 
         self.send_data(spi, &[(y >> 8) as u8])?;
-        self.send_data(spi, &[y as u8])?;
-
+        self.send_data(spi, &[(y & 0xff) as u8])?;
         self.send_data(spi, &[((y + height - 1) >> 8) as u8])?;
-        self.send_data(spi, &[(y + height - 1) as u8])?;
+        self.send_data(spi, &[((y + height - 1) & 0xff) as u8])?;
 
         self.send_data(spi, &[0x01])?; // Gates scan both inside and outside of the partial window. (default)
 
-        //TODO: handle dtm somehow
-        let is_dtm1 = false;
-        if is_dtm1 {
-            self.command(spi, Command::DataStartTransmission1)? //TODO: check if data_start transmission 1 also needs "old"/background data here
-        } else {
-            self.command(spi, Command::DataStartTransmission2)?
-        }
-
+        delay.delay_us(2000);
+        self.command(spi, Command::DataStartTransmission1)?;
         self.send_data(spi, buffer)?;
 
+        let color_value = self.color.get_bit_value();
+        self.interface.cmd(spi, Command::DataStartTransmission2)?;
+        self.interface
+            .data_x_times(spi, color_value, WIDTH / 8 * HEIGHT)?;
+
+        delay.delay_us(2000);
         self.command(spi, Command::PartialOut)?;
         Ok(())
     }
 
     fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle(spi, delay)?;
+        self.set_lut(spi, delay, None)?;
         self.command(spi, Command::DisplayRefresh)?;
+        delay.delay_us(100_000);
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
@@ -310,7 +364,7 @@ where
         self.wait_until_idle(spi, delay)?;
         self.send_resolution(spi)?;
 
-        let color_value = self.color.get_byte_value();
+        let color_value = self.color.get_bit_value();
 
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
         self.interface
@@ -353,7 +407,7 @@ where
     }
 }
 
-impl<SPI, CS, BUSY, DC, RST, DELAY> Epd4in2<SPI, CS, BUSY, DC, RST, DELAY>
+impl<SPI, CS, BUSY, DC, RST, DELAY> Epd4in2bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -449,7 +503,7 @@ where
 }
 
 impl<SPI, CS, BUSY, DC, RST, DELAY> QuickRefresh<SPI, CS, BUSY, DC, RST, DELAY>
-    for Epd4in2<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd4in2bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -482,7 +536,7 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         self.wait_until_idle(spi, delay)?;
-        // self.send_resolution(spi)?;
+        self.send_resolution(spi)?;
 
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
 
@@ -608,6 +662,6 @@ mod tests {
     fn epd_size() {
         assert_eq!(WIDTH, 400);
         assert_eq!(HEIGHT, 300);
-        assert_eq!(DEFAULT_BACKGROUND_COLOR, Color::White);
+        assert_eq!(DEFAULT_BACKGROUND_COLOR, TriColor::White);
     }
 }

--- a/src/epd5in65f/mod.rs
+++ b/src/epd5in65f/mod.rs
@@ -24,7 +24,7 @@ use crate::buffer_len;
 pub type Display5in65f = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize * 4) },
     OctColor,
 >;

--- a/src/epd5in83b_v2/mod.rs
+++ b/src/epd5in83b_v2/mod.rs
@@ -25,7 +25,7 @@ use crate::buffer_len;
 pub type Display5in83 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize * 2) },
     TriColor,
 >;

--- a/src/epd7in5/mod.rs
+++ b/src/epd7in5/mod.rs
@@ -24,7 +24,7 @@ use crate::buffer_len;
 pub type Display7in5 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -27,7 +27,7 @@ use crate::buffer_len;
 pub type Display7in5 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -28,7 +28,7 @@ use crate::buffer_len;
 pub type Display7in5 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     Color,
 >;

--- a/src/epd7in5_v3/mod.rs
+++ b/src/epd7in5_v3/mod.rs
@@ -27,7 +27,7 @@ use crate::buffer_len;
 pub type Display7in5 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize) },
     TriColor,
 >;

--- a/src/epd7in5b_v2/mod.rs
+++ b/src/epd7in5b_v2/mod.rs
@@ -28,7 +28,7 @@ use crate::buffer_len;
 pub type Display7in5 = crate::graphics::Display<
     WIDTH,
     HEIGHT,
-    false,
+    { crate::graphics::DisplayMode::BwrBitOff as u8 },
     { buffer_len(WIDTH as usize, HEIGHT as usize * 2) },
     TriColor,
 >;

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -5,9 +5,10 @@ use core::marker::PhantomData;
 use embedded_graphics_core::prelude::*;
 
 /// Display rotation, only 90° increments supported
-#[derive(Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 pub enum DisplayRotation {
     /// No rotation
+    #[default]
     Rotate0,
     /// Rotate by 90 degrees clockwise
     Rotate90,
@@ -17,9 +18,29 @@ pub enum DisplayRotation {
     Rotate270,
 }
 
-impl Default for DisplayRotation {
-    fn default() -> Self {
-        DisplayRotation::Rotate0
+/// DisplayMode carries modes avaiable for color representaion on TriColor displays
+/// Each mode contains list of (bw, color) pairs, where bw - value for BW layer, color - value for Chromatic layer
+#[repr(u8)]
+pub enum DisplayMode {
+    /// BwrBitOn chromatic doesn't override white, white bit cleared for black, white bit set for white, both bits set for chromatic
+    /// Colors: White - (0xFF, 0); Black - (0, 0); Red - (0, 0xFF)
+    BwrBitOn = 0,
+    /// BwrBitOff is chromatic does override white, both bits cleared for black, white bit set for white, red bit set for black
+    /// Colors: White - (0xFF, 0); Black - (0, 0); Red - (0xFF, 0xFF)
+    BwrBitOff = 1,
+    /// BwrBitOnColorInverted is same as standard, but with color layer values inverted
+    /// Colors: White - (0xFF, 0xFF); Black - (0, 0xFF); Red - (0, 0)
+    BwrBitOnColorInverted = 2,
+}
+
+impl DisplayMode {
+    fn from_u8(value: u8) -> DisplayMode {
+        match value {
+            0 => DisplayMode::BwrBitOn,
+            1 => DisplayMode::BwrBitOff,
+            2 => DisplayMode::BwrBitOnColorInverted,
+            v => panic!("Unsupported DisplayMode value {v}"),
+        }
     }
 }
 
@@ -34,13 +55,13 @@ const fn line_bytes(width: u32, bits_per_pixel: usize) -> usize {
 ///
 /// - WIDTH: width in pixel when display is not rotated
 /// - HEIGHT: height in pixel when display is not rotated
-/// - BWRBIT: mandatory value of the B/W when chromatic bit is set, can be any value for non
+/// - MODE: mandatory value of the B/W when chromatic bit is set, can be any value for non
 ///           tricolor epd
 /// - COLOR: color type used by the target display
 /// - BYTECOUNT: This is redundant with prvious data and should be removed when const generic
 ///              expressions are stabilized
 ///
-/// More on BWRBIT:
+/// More on MODE:
 ///
 /// Different chromatic displays differently treat the bits in chromatic color planes.
 /// Some of them ([crate::epd2in13bc]) will render a color pixel if bit is set for that pixel,
@@ -49,12 +70,12 @@ const fn line_bytes(width: u32, bits_per_pixel: usize) -> usize {
 /// Other displays, like [crate::epd5in83b_v2] in opposite, will draw color pixel if bit is
 /// cleared for that pixel, which is a [DisplayColorRendering::Negative] mode.
 ///
-/// BWRBIT=true: chromatic doesn't override white, white bit cleared for black, white bit set for white, both bits set for chromatic
-/// BWRBIT=false: chromatic does override white, both bits cleared for black, white bit set for white, red bit set for black
+/// MODE=true: chromatic doesn't override white, white bit cleared for black, white bit set for white, both bits set for chromatic
+/// MODE=false: chromatic does override white, both bits cleared for black, white bit set for white, red bit set for black
 pub struct Display<
     const WIDTH: u32,
     const HEIGHT: u32,
-    const BWRBIT: bool,
+    const MODE: u8,
     const BYTECOUNT: usize,
     COLOR: ColorType,
 > {
@@ -66,10 +87,10 @@ pub struct Display<
 impl<
         const WIDTH: u32,
         const HEIGHT: u32,
-        const BWRBIT: bool,
+        const MODE: u8,
         const BYTECOUNT: usize,
         COLOR: ColorType,
-    > Default for Display<WIDTH, HEIGHT, BWRBIT, BYTECOUNT, COLOR>
+    > Default for Display<WIDTH, HEIGHT, MODE, BYTECOUNT, COLOR>
 {
     /// Initialize display with the color '0', which may not be the same on all device.
     /// Many devices have a bit parameter polarity that should be changed if this is not the right
@@ -94,10 +115,10 @@ impl<
 impl<
         const WIDTH: u32,
         const HEIGHT: u32,
-        const BWRBIT: bool,
+        const MODE: u8,
         const BYTECOUNT: usize,
         COLOR: ColorType,
-    > DrawTarget for Display<WIDTH, HEIGHT, BWRBIT, BYTECOUNT, COLOR>
+    > DrawTarget for Display<WIDTH, HEIGHT, MODE, BYTECOUNT, COLOR>
 {
     type Color = COLOR;
     type Error = core::convert::Infallible;
@@ -117,10 +138,10 @@ impl<
 impl<
         const WIDTH: u32,
         const HEIGHT: u32,
-        const BWRBIT: bool,
+        const MODE: u8,
         const BYTECOUNT: usize,
         COLOR: ColorType,
-    > OriginDimensions for Display<WIDTH, HEIGHT, BWRBIT, BYTECOUNT, COLOR>
+    > OriginDimensions for Display<WIDTH, HEIGHT, MODE, BYTECOUNT, COLOR>
 {
     fn size(&self) -> Size {
         match self.rotation {
@@ -133,10 +154,10 @@ impl<
 impl<
         const WIDTH: u32,
         const HEIGHT: u32,
-        const BWRBIT: bool,
+        const MODE: u8,
         const BYTECOUNT: usize,
         COLOR: ColorType,
-    > Display<WIDTH, HEIGHT, BWRBIT, BYTECOUNT, COLOR>
+    > Display<WIDTH, HEIGHT, MODE, BYTECOUNT, COLOR>
 {
     /// get internal buffer to use it (to draw in epd)
     pub fn buffer(&self) -> &[u8] {
@@ -158,20 +179,13 @@ impl<
 
     /// Set a specific pixel color on this display
     pub fn set_pixel(&mut self, pixel: Pixel<COLOR>) {
-        set_pixel(
-            &mut self.buffer,
-            WIDTH,
-            HEIGHT,
-            self.rotation,
-            BWRBIT,
-            pixel,
-        );
+        set_pixel(&mut self.buffer, WIDTH, HEIGHT, self.rotation, MODE, pixel);
     }
 }
 
 /// Some Tricolor specifics
-impl<const WIDTH: u32, const HEIGHT: u32, const BWRBIT: bool, const BYTECOUNT: usize>
-    Display<WIDTH, HEIGHT, BWRBIT, BYTECOUNT, TriColor>
+impl<const WIDTH: u32, const HEIGHT: u32, const MODE: u8, const BYTECOUNT: usize>
+    Display<WIDTH, HEIGHT, MODE, BYTECOUNT, TriColor>
 {
     /// get black/white internal buffer to use it (to draw in epd)
     pub fn bw_buffer(&self) -> &[u8] {
@@ -190,7 +204,7 @@ impl<const WIDTH: u32, const HEIGHT: u32, const BWRBIT: bool, const BYTECOUNT: u
 pub struct VarDisplay<'a, COLOR: ColorType> {
     width: u32,
     height: u32,
-    bwrbit: bool,
+    mode: u8,
     buffer: &'a mut [u8],
     rotation: DisplayRotation,
     _color: PhantomData<COLOR>,
@@ -237,17 +251,17 @@ impl<'a, COLOR: ColorType> VarDisplay<'a, COLOR> {
     /// You must allocate the buffer by yourself, it must be large enough to contain all pixels.
     ///
     /// Parameters are documented in `Display` as they are the same as the const generics there.
-    /// bwrbit should be false for non tricolor displays
+    /// MODE should be false for non tricolor displays
     pub fn new(
         width: u32,
         height: u32,
         buffer: &'a mut [u8],
-        bwrbit: bool,
+        mode: u8,
     ) -> Result<Self, VarDisplayError> {
         let myself = Self {
             width,
             height,
-            bwrbit,
+            mode,
             buffer,
             rotation: DisplayRotation::default(),
             _color: PhantomData,
@@ -294,7 +308,7 @@ impl<'a, COLOR: ColorType> VarDisplay<'a, COLOR> {
             self.width,
             self.height,
             self.rotation,
-            self.bwrbit,
+            self.mode,
             pixel,
         );
     }
@@ -322,7 +336,7 @@ fn set_pixel<COLOR: ColorType>(
     width: u32,
     height: u32,
     rotation: DisplayRotation,
-    bwrbit: bool,
+    mode: u8,
     pixel: Pixel<COLOR>,
 ) {
     let Pixel(point, color) = pixel;
@@ -342,9 +356,10 @@ fn set_pixel<COLOR: ColorType>(
         return;
     }
 
+    let display_mode = DisplayMode::from_u8(mode);
     let index = x as usize * COLOR::BITS_PER_PIXEL_PER_BUFFER / 8
         + y as usize * line_bytes(width, COLOR::BITS_PER_PIXEL_PER_BUFFER);
-    let (mask, bits) = color.bitmask(bwrbit, x as u32);
+    let (mask, bits) = color.bitmask(display_mode, x as u32);
 
     if COLOR::BUFFER_COUNT == 2 {
         // split buffer is for tricolor displays that use 2 buffer for 2 bits per pixel
@@ -369,14 +384,15 @@ mod tests {
     #[test]
     fn graphics_size() {
         // example definition taken from epd1in54
-        let display = Display::<200, 200, false, { 200 * 200 / 8 }, Color>::default();
+        let display = Display::<200, 200,     { DisplayMode::BwrBitOff as u8 }
+        , { 200 * 200 / 8 }, Color>::default();
         assert_eq!(display.buffer().len(), 5000);
     }
 
     // test default background color on all bytes
     #[test]
     fn graphics_default() {
-        let display = Display::<200, 200, false, { 200 * 200 / 8 }, Color>::default();
+        let display = Display::<200, 200, { DisplayMode::BwrBitOff as u8 }, { 200 * 200 / 8 }, Color>::default();
         for &byte in display.buffer() {
             assert_eq!(byte, 0);
         }
@@ -384,7 +400,13 @@ mod tests {
 
     #[test]
     fn graphics_rotation_0() {
-        let mut display = Display::<200, 200, false, { 200 * 200 / 8 }, Color>::default();
+        let mut display = Display::<
+            200,
+            200,
+            { DisplayMode::BwrBitOff as u8 },
+            { 200 * 200 / 8 },
+            Color,
+        >::default();
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
             .into_styled(PrimitiveStyle::with_stroke(Color::Black, 1))
             .draw(&mut display);
@@ -400,7 +422,13 @@ mod tests {
 
     #[test]
     fn graphics_rotation_90() {
-        let mut display = Display::<200, 200, false, { 200 * 200 / 8 }, Color>::default();
+        let mut display = Display::<
+            200,
+            200,
+            { DisplayMode::BwrBitOff as u8 },
+            { 200 * 200 / 8 },
+            Color,
+        >::default();
         display.set_rotation(DisplayRotation::Rotate90);
         let _ = Line::new(Point::new(0, 192), Point::new(0, 199))
             .into_styled(PrimitiveStyle::with_stroke(Color::Black, 1))
@@ -417,7 +445,13 @@ mod tests {
 
     #[test]
     fn graphics_rotation_180() {
-        let mut display = Display::<200, 200, false, { 200 * 200 / 8 }, Color>::default();
+        let mut display = Display::<
+            200,
+            200,
+            { DisplayMode::BwrBitOff as u8 },
+            { 200 * 200 / 8 },
+            Color,
+        >::default();
         display.set_rotation(DisplayRotation::Rotate180);
         let _ = Line::new(Point::new(192, 199), Point::new(199, 199))
             .into_styled(PrimitiveStyle::with_stroke(Color::Black, 1))
@@ -426,7 +460,7 @@ mod tests {
         let buffer = display.buffer();
 
         extern crate std;
-        std::println!("{:?}", buffer);
+        std::println!("{buffer:?}");
 
         assert_eq!(buffer[0], Color::Black.get_byte_value());
 
@@ -437,7 +471,13 @@ mod tests {
 
     #[test]
     fn graphics_rotation_270() {
-        let mut display = Display::<200, 200, false, { 200 * 200 / 8 }, Color>::default();
+        let mut display = Display::<
+            200,
+            200,
+            { DisplayMode::BwrBitOff as u8 },
+            { 200 * 200 / 8 },
+            Color,
+        >::default();
         display.set_rotation(DisplayRotation::Rotate270);
         let _ = Line::new(Point::new(199, 0), Point::new(199, 7))
             .into_styled(PrimitiveStyle::with_stroke(Color::Black, 1))
@@ -446,7 +486,7 @@ mod tests {
         let buffer = display.buffer();
 
         extern crate std;
-        std::println!("{:?}", buffer);
+        std::println!("{buffer:?}");
 
         assert_eq!(buffer[0], Color::Black.get_byte_value());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub mod epd2in9_v2;
 pub mod epd2in9bc;
 pub mod epd3in7;
 pub mod epd4in2;
+pub mod epd4in2bc;
 pub mod epd5in65f;
 pub mod epd5in83b_v2;
 pub mod epd7in5;
@@ -105,7 +106,7 @@ pub mod prelude {
     pub use crate::SPI_MODE;
 
     #[cfg(feature = "graphics")]
-    pub use crate::graphics::{Display, DisplayRotation};
+    pub use crate::graphics::{Display, DisplayMode, DisplayRotation};
 }
 
 /// Computes the needed buffer length. Takes care of rounding up in case width

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,19 +11,14 @@ pub(crate) trait Command: Copy {
 }
 
 /// Seperates the different LUT for the Display Refresh process
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Copy)]
 pub enum RefreshLut {
     /// The "normal" full Lookuptable for the Refresh-Sequence
+    #[default]
     Full,
     /// The quick LUT where not the full refresh sequence is followed.
     /// This might lead to some
     Quick,
-}
-
-impl Default for RefreshLut {
-    fn default() -> Self {
-        RefreshLut::Full
-    }
 }
 
 pub(crate) trait InternalWiAdditions<SPI, CS, BUSY, DC, RST, DELAY>
@@ -284,7 +279,7 @@ where
 ///let (x, y, frame_width, frame_height) = (20, 40, 80,80);
 ///
 ///let mut buffer = [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 80 / 8 * 80];
-///let mut display = VarDisplay::new(frame_width, frame_height, &mut buffer,false).unwrap();
+///let mut display = VarDisplay::new(frame_width, frame_height, &mut buffer, DisplayMode::BwrBitOff as u8).unwrap();
 ///
 ///epd.update_partial_old_frame(&mut spi, &mut delay, display.buffer(), x, y, frame_width, frame_height)
 ///  .ok();


### PR DESCRIPTION
So... Does it work? Well, mostly. Display works fine as far as I can tell, however color coding is broken. For some reason `4in2bc` uses a completely different scheme than anything implemented.

```
// 4in2bc
// White bw - 0xFF c - 0xFF
// Black bw - 0 c - 0xFF
// Red bw - 0 c - 0

// bwrbit = true
// White: bw - 0xFF c - 0
// Black: bw - 0 c - 0
// Red: bw - 0 c - 0xFF

// bwrbit = false
// White: bw - 0xFF c - 0
// Black: bw - 0 c - 0
// Red: bw - 0xFF c - 0xFF
```

@caemor could you help with extending `TriColor` implementation to match these requirements? I am willing to do it myself, let's just agree on the best way to approach it. Thanks!
