### PR TITLE
fix: overflow error

### DIFF
--- a/src/epd7in5b_v2/mod.rs
+++ b/src/epd7in5b_v2/mod.rs
@@ -41,7 +41,7 @@ pub const HEIGHT: u32 = 480;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
 
-const NUM_DISPLAY_BYTES: usize = WIDTH as usize * HEIGHT as usize / 8;
+const NUM_DISPLAY_BYTES: usize = WIDTH as usize / 8 * HEIGHT as usize;
 const IS_BUSY_LOW: bool = true;
 const SINGLE_BYTE_WRITE: bool = false;
 


### PR DESCRIPTION
Currently on my computer it displays an error message: 
```
44 | const NUM_DISPLAY_BYTES: usize = WIDTH as usize  * HEIGHT as usize /8;
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `800_usize * 480_usize`, which would overflow
```
as said in #151.
This a fix to this error (when compiling for arduino, in my case).