### PR TITLE
Custom generators for loading achromatic/chromatic frame updates

### DIFF
--- a/src/epd2in13b_v4/mod.rs
+++ b/src/epd2in13b_v4/mod.rs
@@ -177,7 +177,7 @@ where
     /// Useful for rendering directly from progmem buffers.
     ///
     /// Example:
-    /// ```rust
+    /// ```rust no_run
     /// progmem! {
     ///     static progmem BLACK: [u8; 4000] = *include_bytes!("black.gray");
     ///     static progmem RED: [u8; 4000] = *include_bytes!("red.gray");

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -76,6 +76,30 @@ where
         Ok(())
     }
 
+    /// Basic function for sending u8-values with the provided generator.
+    ///
+    /// Intented for use with rendering from progmem buffers.
+    pub(crate) fn data_with(
+        &mut self,
+        spi: &mut SPI,
+        data: impl Fn(usize) -> u8,
+        len: usize,
+    ) -> Result<(), SPI::Error> {
+        // high for data
+        let _ = self.dc.set_high();
+
+        if SINGLE_BYTE_WRITE {
+            for i in 0..len {
+                // Transfer data one u8 at a time over spi
+                self.write(spi, &[data(i)])?;
+            }
+        } else {
+            unimplemented!();
+        }
+
+        Ok(())
+    }
+
     /// Basic function for sending [Commands](Command) and the data belonging to it.
     ///
     /// TODO: directly use ::write? cs wouldn't needed to be changed twice than


### PR DESCRIPTION
Currently only implemented for `Epd2in13b`. The reason this is needed is that for many arduino boards, having both two buffers directly on the stack would consume too much space, failing the compilation.

However, with progmem, we can save the buffers on the flash and read them byte-by-byte to send them.
it's probably inevitable that this needs to be abstracted to a trait level implementation, but I'm unsure of what the naming should be; or which boards shall implement this.