### PR TITLE
Exposed buffer_mut

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -138,6 +138,11 @@ impl<
         &self.buffer
     }
 
+    /// get internal buffer as mutable
+    pub fn buffer_mut(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
     /// Set the display rotation.
     ///
     /// This only concerns future drawing made to it. Anything aready drawn


### PR DESCRIPTION
Fixes #256
This allows callers to apply transformations to the buffer, for example to work around the color inversion on 7in5_v2: `display.buffer_mut().iter_mut().for_each(|b| *b = !*b)`
