### PR TITLE
fix(epd7in5_v2): match Waveshare reference framebuffer polarity

### DIFF
--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -131,7 +131,16 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         self.wait_until_idle(spi, delay)?;
-        self.cmd_with_data(spi, Command::DataStartTransmission2, buffer)?;
+        // Waveshare's reference C demo (EPD_7in5_V2.c::EPD_7IN5_V2_Display)
+        // sends the framebuffer to DTM1 (0x10) raw and to DTM2 (0x13) bitwise-
+        // inverted. The user-facing convention is bit 1 = white; the panel's
+        // DTM2 register expects bit 0 = white (datasheet §22, KW mode with
+        // NEW/OLD, DDX=00). Writing both DTM1 and DTM2 with opposite polarity
+        // forces a full LUTKW/LUTWK transition for every pixel, producing
+        // strong contrast. Without this, every framebuffer renders inverted.
+        self.cmd_with_data(spi, Command::DataStartTransmission1, buffer)?;
+        self.command(spi, Command::DataStartTransmission2)?;
+        self.interface.data_inverted(spi, buffer)?;
         Ok(())
     }
 
@@ -169,8 +178,11 @@ where
         self.wait_until_idle(spi, delay)?;
         self.send_resolution(spi)?;
 
+        // Match Waveshare's `EPD_7IN5_V2_Clear` (DTM1=0xFF, DTM2=0x00) so
+        // every pixel transitions black->white via LUTKW. See `update_frame`
+        // for the polarity rationale.
         self.command(spi, Command::DataStartTransmission1)?;
-        self.interface.data_x_times(spi, 0x00, WIDTH / 8 * HEIGHT)?;
+        self.interface.data_x_times(spi, 0xFF, WIDTH / 8 * HEIGHT)?;
 
         self.command(spi, Command::DataStartTransmission2)?;
         self.interface.data_x_times(spi, 0x00, WIDTH / 8 * HEIGHT)?;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -89,6 +89,23 @@ where
         self.data(spi, data)
     }
 
+    /// Sends data with bytewise bitwise-NOT applied. Streams via a stack chunk
+    /// to avoid heap allocation. Required for displays whose DTM2 register
+    /// expects bit polarity inverted from the user-facing framebuffer (e.g.
+    /// 7.5" V2, where Waveshare's reference C demo
+    /// `EPD_7in5_V2.c::EPD_7IN5_V2_Display` applies the same `~` before 0x13).
+    pub(crate) fn data_inverted(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        let _ = self.dc.set_high();
+        let mut chunk = [0u8; 256];
+        for source in data.chunks(chunk.len()) {
+            for (index, &byte) in source.iter().enumerate() {
+                chunk[index] = !byte;
+            }
+            self.write(spi, &chunk[..source.len()])?;
+        }
+        Ok(())
+    }
+
     /// Basic function for sending the same byte of data (one u8) multiple times over spi
     ///
     /// Enables direct interaction with the device with the help of [command()](ConnectionInterface::command())


### PR DESCRIPTION
Fixes #256.

## Summary

`update_frame` in `Epd7in5` (V2) was sending the user buffer verbatim to DTM2 (`0x13`), causing every framebuffer to render with bit polarity inverted on the actual panel: `Color::White` (bit 1) showed as black, `Color::Black` (bit 0) showed as white. Symmetric test patterns hide this; any image with asymmetric content does not.

Issue #256 documents the same symptom — the reporter suggested `buffer_mut().iter_mut().for_each(|b| *b = !*b)` as a workaround, which is essentially what this PR does inside the driver.

## Root cause

Waveshare's reference C demo [`EPD_7IN5_V2_Display()`](https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_7in5_V2.c#L314-L335) sends the user buffer raw to DTM1 (`0x10`) and bitwise-NOT to DTM2 (`0x13`). The Python driver [`display()`](https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py#L293-L311) does the same on the wire, just with the opposite user-facing buffer convention (it pre-inverts in [`getbuffer`](https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py#L237-L255) per its own ``e-paper world 0=white, 1=black`` comment).

The panel's DTM2 register expects `bit 0 = white` per the UC8179 datasheet §22, KW mode with NEW/OLD, DDX=00: `{NEW=0, OLD=0} -> LUTWW`. epd-waveshare's `Color::White → bit 1` encoding means the buffer must be inverted before reaching `0x13`.

## Changes

- `DisplayInterface::data_inverted` — new method, streams `~data` via a 256-byte stack chunk (no heap allocation, fits the 48 KB framebuffer comfortably).
- `Epd7in5::update_frame` — writes DTM1 raw + DTM2 inverted, matching the C demo. Writing both forces a full `LUTKW`/`LUTWK` transition for every pixel, producing strong contrast.
- `Epd7in5::clear_frame` — writes DTM1=`0xFF` + DTM2=`0x00`, matching `EPD_7IN5_V2_Clear`. Previously both were `0x00`, which goes through `LUTWW` (stays white) — works for a freshly-powered panel but doesn't force a clean transition from a prior image.

## Verification

Tested on real hardware: ESP32-S3 driving a Waveshare 7.5" e-Paper V2 (G) panel via the Universal Driver HAT Rev 2.3, using esp-hal 1.0 + embedded-hal 1.0. Before the patch, a simple `clear(Color::White)` + `Text "hello world" in Color::Black` framebuffer rendered as solid black with white text. After the patch, it renders correctly white-bg-black-text without any application-side color swap.

`cargo fmt --check`, `cargo check --lib`, and `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps` all pass.

## Test plan

- [x] Build clean (`cargo check --lib`)
- [x] Format clean (`cargo fmt --check`)
- [x] Docs clean (`RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps`)
- [x] Real hardware: 7.5" V2 (G) panel renders white background + black text with no app-side inversion
- [ ] Real hardware: plain 7.5" V2 (non-(G)) — would appreciate a second confirmation from anyone with that variant on hand